### PR TITLE
feat: Enhance LPC syntax highlighting

### DIFF
--- a/src/lpc_test/lpc_syntax_test.c
+++ b/src/lpc_test/lpc_syntax_test.c
@@ -1,0 +1,100 @@
+// Preprocessor Directives Test
+#include <std.h>
+#include "local.h"
+#define MAX_USERS 100
+#define IS_ADMIN(p) (p->query_level() > 5)
+#define DEBUG_MODE
+#undef OLD_FEATURE
+#if MAX_USERS > 50
+  #pragma message "Max users is greater than 50"
+#elif defined(DEBUG_MODE)
+  #warning "Debug mode is active"
+#else
+  #error "Unsupported configuration"
+#endif
+
+// Efun Highlighting Test (examples from config)
+mixed val = allocate(5);
+int is_arr = arrayp(val);
+object ob = clone_object("/obj/thing");
+write("Hello, " + this_player()->query_name() + "
+");
+set_light(10);
+call_out("my_function", 2, "arg");
+
+// Special LPC Functions Test
+void create() {
+    // creation code
+}
+
+void init() {
+    // initialization code
+}
+
+void reset(int arg) {
+    // reset code
+}
+
+// main is not always special but sometimes used as entry
+void main(string arg) {
+    // main code
+}
+
+// Function Pointers and Closures Test
+function f_ptr_simple = #'my_function;
+function f_ptr_object = #'this_object()->query_name;
+function f_ptr_implicit = #'->my_other_function;
+
+mixed closure_val = (: $1 + $2 :);
+mixed complex_closure = (:
+    string local_var = "inside closure";
+    // A comment inside closure
+    if ($1) {
+        return $1->do_something(123, "test");
+    }
+    return 0;
+:);
+
+// Operator Highlighting Test
+int a = 10 + 5 * 2 / 3 % 2;
+a++;
+a--;
+a = b = c; // Assignment
+a += 5; b -= 1; c *= 2; d /= 1; e %= 1;
+f &= 0xFF; g |= 0x01; h ^= 0xAA;
+i <<= 2; j >>= 1;
+status k = (a == b) && (c != d) || !(e < f) && (g > h) && (i <= j) && (k >= a);
+int ternary_result = k ? a : b;
+object room = environment(this_object());
+string name = room->query_short(); // Arrow operator
+// Scope resolution (if used, e.g. for static class members or specific libs)
+// mixed static_val = SomeClass::static_member; (Illustrative, may not be common LPC)
+
+// Type Highlighting Test
+void my_typed_function(int i, string s, object o, array arr, mapping map, float f, buffer buf, mixed m, function func_param, class MyClass c_inst, struct MyStruct s_inst) {
+    // function body
+}
+
+// Number Highlighting Test
+int int_val = 12345;
+int hex_val = 0xDeadBeef;
+int oct_val = 0777; // Octal
+int zero_val = 0;
+float float_val1 = 1.0;
+float float_val2 = .5;
+float float_val3 = 100.;
+float float_val4 = 1.5e-2;
+float float_val5 = 2E+3;
+
+// Test for interactions and edge cases
+#define MACRO_WITH_OPERATOR (1+2)
+int test_macro_op = MACRO_WITH_OPERATOR;
+string path = "/u/j/jules/workroom.c"; // String
+/* Block comment
+   with multiple lines
+   and operators + - * / inside
+*/
+mapping test_map = ([ "key" : "value", "another":123 ]);
+array test_arr = ({ 1, "two", 0x03, #'create });
+
+// End of test file

--- a/syntaxes/lpc.tmLanguage.json
+++ b/syntaxes/lpc.tmLanguage.json
@@ -28,11 +28,147 @@
 			"include": "#operators"
 		},
 		{
+			"name": "meta.closure.lpc",
+			"begin": "(\\(:)",
+			"beginCaptures": {
+				"1": { "name": "punctuation.definition.closure.begin.lpc" }
+			},
+			"end": "(:\))",
+			"endCaptures": {
+				"1": { "name": "punctuation.definition.closure.end.lpc" }
+			},
+			"patterns": [
+				{ "include": "#comments" },
+				{ "include": "#strings" },
+				{ "include": "#keywords" },
+				{ "include": "#types" },
+				{ "include": "#variables" },
+				{ "include": "#numbers" },
+				{ "include": "#operators" },
+				{ "include": "#functions" }
+			]
+		},
+		{
 			"name": "meta.preprocessor.include.lpc",
 			"match": "^\\s*(#\\s*include)\\b\\s*([<\"].*?[\">])",
 			"captures": {
 				"1": { "name": "keyword.control.import.include.lpc" },
 				"2": { "name": "string.quoted.other.lt-gt.include.lpc" }
+			}
+		},
+		{
+			"name": "meta.preprocessor.define.lpc",
+			"match": "^\\s*(#\\s*define)\\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:\\(([^)]*)\\))?(?:\\s+(.*))?$",
+			"captures": {
+				"1": { "name": "keyword.control.preprocessor.define.lpc" },
+				"2": { "name": "entity.name.constant.macro.lpc" },
+				"3": { "name": "variable.parameter.macro.lpc" },
+				"4": { "name": "string.unquoted.preprocessor.macro-value.lpc" }
+			}
+		},
+		{
+			"name": "meta.preprocessor.undef.lpc",
+			"match": "^\\s*(#\\s*undef)\\s+([a-zA-Z_][a-zA-Z0-9_]*)$",
+			"captures": {
+				"1": { "name": "keyword.control.preprocessor.undef.lpc" },
+				"2": { "name": "entity.name.constant.macro.lpc" }
+			}
+		},
+		{
+			"name": "meta.preprocessor.if.lpc",
+			"match": "^\\s*(#\\s*if)(.*)$",
+			"captures": {
+				"1": { "name": "keyword.control.preprocessor.conditional.lpc" },
+				"2": { "name": "meta.preprocessor.conditional.condition.lpc" }
+			}
+		},
+		{
+			"name": "meta.preprocessor.ifdef.lpc",
+			"match": "^\\s*(#\\s*ifdef)\\s+(.*)$",
+			"captures": {
+				"1": { "name": "keyword.control.preprocessor.conditional.lpc" },
+				"2": { "name": "entity.name.constant.macro.lpc" }
+			}
+		},
+		{
+			"name": "meta.preprocessor.ifndef.lpc",
+			"match": "^\\s*(#\\s*ifndef)\\s+(.*)$",
+			"captures": {
+				"1": { "name": "keyword.control.preprocessor.conditional.lpc" },
+				"2": { "name": "entity.name.constant.macro.lpc" }
+			}
+		},
+		{
+			"name": "meta.preprocessor.else.lpc",
+			"match": "^\\s*(#\\s*else)\\b",
+			"captures": {
+				"1": { "name": "keyword.control.preprocessor.conditional.lpc" }
+			}
+		},
+		{
+			"name": "meta.preprocessor.elif.lpc",
+			"match": "^\\s*(#\\s*elif)(.*)$",
+			"captures": {
+				"1": { "name": "keyword.control.preprocessor.conditional.lpc" },
+				"2": { "name": "meta.preprocessor.conditional.condition.lpc" }
+			}
+		},
+		{
+			"name": "meta.preprocessor.endif.lpc",
+			"match": "^\\s*(#\\s*endif)\\b",
+			"captures": {
+				"1": { "name": "keyword.control.preprocessor.conditional.lpc" }
+			}
+		},
+		{
+			"name": "meta.preprocessor.pragma.lpc",
+			"match": "^\\s*(#\\s*pragma)(.*)$",
+			"captures": {
+				"1": { "name": "keyword.control.preprocessor.pragma.lpc" },
+				"2": { "name": "string.unquoted.preprocessor.message.lpc" }
+			}
+		},
+		{
+			"name": "meta.preprocessor.error.lpc",
+			"match": "^\\s*(#\\s*error)(.*)$",
+			"captures": {
+				"1": { "name": "keyword.control.preprocessor.error.lpc" },
+				"2": { "name": "string.unquoted.preprocessor.message.lpc" }
+			}
+		},
+		{
+			"name": "meta.preprocessor.warning.lpc",
+			"match": "^\\s*(#\\s*warning)(.*)$",
+			"captures": {
+				"1": { "name": "keyword.control.preprocessor.warning.lpc" },
+				"2": { "name": "string.unquoted.preprocessor.message.lpc" }
+			}
+		},
+		{
+			"name": "meta.function-pointer.simple.lpc",
+			"match": "(#')([a-zA-Z_][a-zA-Z0-9_]*)",
+			"captures": {
+				"1": { "name": "keyword.operator.function-pointer.lpc" },
+				"2": { "name": "entity.name.function.pointer.lpc" }
+			}
+		},
+		{
+			"name": "meta.function-pointer.object.lpc",
+			"match": "(#')((?:[a-zA-Z_][a-zA-Z0-9_]*::)*[a-zA-Z_][a-zA-Z0-9_]*)(\\s*->\\s*)([a-zA-Z_][a-zA-Z0-9_]*)",
+			"captures": {
+				"1": { "name": "keyword.operator.function-pointer.lpc" },
+				"2": { "name": "variable.other.object.path.lpc" },
+				"3": { "name": "keyword.operator.arrow.lpc" },
+				"4": { "name": "entity.name.function.pointer.lpc" }
+			}
+		},
+		{
+			"name": "meta.function-pointer.implicit-this.lpc",
+			"match": "(#')(->\\s*)([a-zA-Z_][a-zA-Z0-9_]*)",
+			"captures": {
+				"1": { "name": "keyword.operator.function-pointer.lpc" },
+				"2": { "name": "keyword.operator.arrow.lpc" },
+				"3": { "name": "entity.name.function.pointer.lpc" }
 			}
 		},
 		{
@@ -98,6 +234,15 @@
 		"functions": {
 			"patterns": [
 				{
+					"name": "support.function.efun.lpc",
+					"match": "\\b(allocate_buffer|allocate_mapping|call_out_walltime|disassemble_class|fetch_class_member|function_exists|query_heart_beat|query_load_average|query_shadowing|remove_call_out|replace_string|reset_eval_cost|restore_variable|set_living_name|set_malloc_mask|store_class_member|telnet_msp_oob|this_interactive|async_db_exec|async_getdir|element_of|filter_array|member_array|previous_object|query_ip_name|query_ip_number|read_buffer|remove_interactive|set_this_player|socket_create|socket_listen|socket_write|sort_array|unique_array|valid_write|write_buffer|add_action|arrayp|assemble_class|async_read|async_write|base_name|bufferp|call_other|call_out|call_stack|capitalize|classp|clear_bit|clone_object|commands|ctime|db_close|db_commit|db_connect|db_exec|db_fetch|db_rollback|db_status|debug_message|destruct|disable_commands|disable_wizard|dotprod|dump_prog|dump_trace|ed_cmd|ed_start|enable_commands|enable_wizard|environment|eval_cost|evaluate|explode|export_uid|file_size|find_living|find_player|floatp|floor|functionp|get_char|get_dir|geteuid|getuid|heart_beats|implode|inherits|input_to|in_edit|in_input|interactive|keys|living|log10|log2|map_array|map_delete|memory_info|memory_summary|message|mkdir|move_object|network_stats|notify_fail|nullp|origin|pcre_extract|pcre_match|pcre_replace|pluralize|pointerp|present|printf|program_info|query_charmode|query_encoding|query_host_name|query_idle|query_invis|query_ip_port|query_snoop|query_snooping|read_file|real_time|reclaim_objects|receive|reg_assoc|regexp|reload_object|remove_action|rename|restore_object|rusage|save_object|save_variable|set_bit|set_encoding|set_eval_limit|set_heart_beat|set_hide|set_light|set_reset|seteuid|shutdown|shout|shuffle|sizeof|snoop|socket_accept|socket_bind|socket_close|sprintf|sscanf|strlen|strsrch|telnet_ga|telnet_nop|test_bit|this_object|this_player|this_user|throw|time|to_int|trace|traceprefix|trim|typeof|uptime|userp|users|valid_read|values|virtualp|wizardp|write_file|abs|acos|angle|asin|atan|bind|break_string|cache_stats|catch|ceil|classes|command|copy|cos|cp|crypt|defer|distance|ed|exec|exp|fetch_variable|filter|link|log|ltrim|map|master|max|min|norm|pow|resolve|rm|rmdir|rtrim|sin|sqrt|stat|swap|tan)(?=\\s*\\()"
+				},
+				{
+					"name": "entity.name.function.special.lpc",
+					"match": "\\b(create|init|reset|main)\\b(?=\\s*\\()",
+					"comment": "Special LPC functions like create, init, reset, main"
+				},
+				{
 					"name": "entity.name.function.lpc",
 					"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\("
 				}
@@ -111,19 +256,22 @@
 				}
 			]
 		},
-		"objectAccess": {
-			"name": "Object Access",
-			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s*->",
-			"captures": {
-				"1": {
-					"name": "variable.object.lpc"
-				}
-			}
-		},
 		"numbers": {
 			"patterns": [
 				{
-					"name": "constant.numeric.lpc",
+					"name": "constant.numeric.hex.lpc",
+					"match": "\\b0[xX][0-9a-fA-F]+\\b"
+				},
+				{
+					"name": "constant.numeric.octal.lpc",
+					"match": "\\b0[0-7]+\\b"
+				},
+				{
+					"name": "constant.numeric.float.lpc",
+					"match": "\\b(?:(?:\\d*\\.\\d+)|(?:\\d+\\.\\d*))(?:[eE][+-]?\\d+)?\\b|\\b\\d+[eE][+-]?\\d+\\b"
+				},
+				{
+					"name": "constant.numeric.integer.lpc",
 					"match": "\\b\\d+\\b"
 				}
 			]
@@ -131,8 +279,40 @@
 		"operators": {
 			"patterns": [
 				{
+					"name": "meta.member.access.lpc",
+					"match": "([a-zA-Z_][a-zA-Z0-9_]*)\\s*(->)",
+					"captures": {
+						"1": { "name": "variable.other.object.access.lpc" },
+						"2": { "name": "keyword.operator.arrow.lpc" }
+					}
+				},
+				{
+					"name": "keyword.operator.assignment.lpc",
+					"match": "(?:\\+=|-=|\\*=|/=|%=|&=|\\|=|\\^=|<<=|>>=|=)"
+				},
+				{
 					"name": "keyword.operator.arithmetic.lpc",
-					"match": "[+\\-*/%]"
+					"match": "(?:\\+\\+|--|\\+|-|\\*|/|%)"
+				},
+				{
+					"name": "keyword.operator.comparison.lpc",
+					"match": "(?:==|!=|<=|>=|<|>)"
+				},
+				{
+					"name": "keyword.operator.logical.lpc",
+					"match": "(?:&&|\\|\\||!)"
+				},
+				{
+					"name": "keyword.operator.bitwise.lpc",
+					"match": "(?:&|\\||\\^|~|<<|>>)"
+				},
+				{
+					"name": "keyword.operator.ternary.lpc",
+					"match": "(?:\\?|:)"
+				},
+				{
+					"name": "keyword.operator.scope-resolution.lpc",
+					"match": "::"
 				}
 			]
 		}


### PR DESCRIPTION
Improves syntax highlighting for the LPC language by:

- Adding comprehensive preprocessor directive support (#define, #undef, #if, #ifdef, #ifndef, #else, #elif, #endif, #pragma, #error, #warning).
- Highlighting Efuns listed in `config/lpc-config.json` with a specific scope.
- Highlighting special LPC functions: `create`, `init`, `reset`, `main`.
- Adding support for function pointers (`#'func`, `#'obj->func`, `#'->func`) and closures (`(: ... :)`).
- Refining operator highlighting with categorization (arithmetic, assignment, comparison, logical, bitwise, ternary, arrow, scope-resolution).
- Verifying and ensuring robust highlighting for standard LPC types.
- Improving number highlighting for integers, floats, hexadecimal, and octal numbers.

Includes a new file `src/lpc_test/lpc_syntax_test.c` to demonstrate these enhancements.