### PR TITLE
Fix: Correctly handle go-to-definition for functions when preceded by…

### DIFF
--- a/src/definitionProvider.ts
+++ b/src/definitionProvider.ts
@@ -31,7 +31,7 @@ export class LPCDefinitionProvider implements vscode.DefinitionProvider {
 
         // Check for "->" operator
         if (line.includes('->')) {
-            const regex = new RegExp(`(.*?)->\\s*${word}`);
+            const regex = new RegExp(`([a-zA-Z_][a-zA-Z0-9_]*|\\"(?:\\\\.|[^\\"])*\\")\\s*->\\s*${word}`);
             const match = regex.exec(line);
             if (match) {
                 const targetObject = match[1].trim();


### PR DESCRIPTION
… parenthesis

The previous regular expression for identifying the target object in a function call (e.g., `object->function()`) was too greedy. It would incorrectly include any preceding opening parenthesis as part of the object name. This prevented the definition provider from correctly resolving the object and subsequently finding the function definition, especially when the object was a macro expanding to a file path.

This commit updates the regex to be more specific, correctly capturing either an identifier (for macros or variable names) or a double-quoted string literal as the target object, ignoring any leading parentheses. This ensures that "go to definition" works correctly in cases like: `(EMOTE_D->do_emote(me, verb, arg))`