### PR TITLE
⚡ perf: eliminate redundant array allocations in TypeDiagnosticsCollector

### DIFF
--- a/benchmark.ts
+++ b/benchmark.ts
@@ -1,0 +1,57 @@
+import { performance } from 'perf_hooks';
+
+const SyntaxKind = {
+    AssignmentExpression: 1,
+    Other: 2
+};
+
+const nodes = [];
+for (let i = 0; i < 100000; i++) {
+    nodes.push({
+        kind: i % 10 === 0 ? SyntaxKind.AssignmentExpression : SyntaxKind.Other,
+        metadata: { operator: '=' },
+        children: [{}, {}]
+    });
+}
+
+function runFilter(nodes) {
+    let count = 0;
+    for (const assignment of nodes.filter((node) => node.kind === SyntaxKind.AssignmentExpression)) {
+        if (assignment.metadata?.operator !== '=') continue;
+        count++;
+    }
+    return count;
+}
+
+function runNoFilter(nodes) {
+    let count = 0;
+    for (const node of nodes) {
+        if (node.kind !== SyntaxKind.AssignmentExpression) continue;
+        const assignment = node;
+        if (assignment.metadata?.operator !== '=') continue;
+        count++;
+    }
+    return count;
+}
+
+// Warmup
+for (let i = 0; i < 100; i++) {
+    runFilter(nodes);
+    runNoFilter(nodes);
+}
+
+// Benchmark
+const filterStart = performance.now();
+for (let i = 0; i < 1000; i++) {
+    runFilter(nodes);
+}
+const filterEnd = performance.now();
+
+const noFilterStart = performance.now();
+for (let i = 0; i < 1000; i++) {
+    runNoFilter(nodes);
+}
+const noFilterEnd = performance.now();
+
+console.log(`Baseline (Filter): ${filterEnd - filterStart} ms`);
+console.log(`Optimized (No Filter): ${noFilterEnd - noFilterStart} ms`);

--- a/src/diagnostics/collectors/TypeDiagnosticsCollector.ts
+++ b/src/diagnostics/collectors/TypeDiagnosticsCollector.ts
@@ -118,8 +118,14 @@ export class TypeDiagnosticsCollector implements IDiagnosticCollector {
         session: TypeCheckingSession,
         diagnostics: vscode.Diagnostic[]
     ): void {
-        for (const declaration of nodes.filter((node) => node.kind === SyntaxKind.VariableDeclaration)) {
-            for (const declarator of declaration.children.filter((child) => child.kind === SyntaxKind.VariableDeclarator)) {
+        for (const declaration of nodes) {
+            if (declaration.kind !== SyntaxKind.VariableDeclaration) {
+                continue;
+            }
+            for (const declarator of declaration.children) {
+                if (declarator.kind !== SyntaxKind.VariableDeclarator) {
+                    continue;
+                }
                 const initializer = declarator.children[1];
                 if (!initializer || !declarator.name) {
                     continue;
@@ -143,7 +149,10 @@ export class TypeDiagnosticsCollector implements IDiagnosticCollector {
         session: TypeCheckingSession,
         diagnostics: vscode.Diagnostic[]
     ): void {
-        for (const assignment of nodes.filter((node) => node.kind === SyntaxKind.AssignmentExpression)) {
+        for (const assignment of nodes) {
+            if (assignment.kind !== SyntaxKind.AssignmentExpression) {
+                continue;
+            }
             if (assignment.metadata?.operator !== '=') {
                 continue;
             }
@@ -166,7 +175,10 @@ export class TypeDiagnosticsCollector implements IDiagnosticCollector {
         session: TypeCheckingSession,
         diagnostics: vscode.Diagnostic[]
     ): void {
-        for (const returnStatement of nodes.filter((node) => node.kind === SyntaxKind.ReturnStatement)) {
+        for (const returnStatement of nodes) {
+            if (returnStatement.kind !== SyntaxKind.ReturnStatement) {
+                continue;
+            }
             const expression = returnStatement.children[0];
             if (!expression) {
                 continue;
@@ -199,7 +211,10 @@ export class TypeDiagnosticsCollector implements IDiagnosticCollector {
         session: TypeCheckingSession,
         diagnostics: vscode.Diagnostic[]
     ): void {
-        for (const callExpression of nodes.filter((node) => node.kind === SyntaxKind.CallExpression)) {
+        for (const callExpression of nodes) {
+            if (callExpression.kind !== SyntaxKind.CallExpression) {
+                continue;
+            }
             const callSite = getDirectDiagnosticCallSite(callExpression);
             if (!callSite?.callee.name) {
                 continue;
@@ -249,7 +264,10 @@ export class TypeDiagnosticsCollector implements IDiagnosticCollector {
         session: TypeCheckingSession,
         diagnostics: vscode.Diagnostic[]
     ): void {
-        for (const memberAccess of nodes.filter((node) => node.kind === SyntaxKind.MemberAccessExpression)) {
+        for (const memberAccess of nodes) {
+            if (memberAccess.kind !== SyntaxKind.MemberAccessExpression) {
+                continue;
+            }
             const receiverType = session.evaluator.evaluate(memberAccess.children[0]);
             if (receiverType.kind !== 'class' && receiverType.kind !== 'struct') {
                 continue;


### PR DESCRIPTION
💡 **What:** Refactored `collectAssignmentDiagnostics`, `collectVariableInitializerDiagnostics`, `collectReturnDiagnostics`, `collectCallArgumentDiagnostics`, and `collectMemberDiagnostics` in `src/diagnostics/collectors/TypeDiagnosticsCollector.ts` to replace redundant intermediate array creations via `.filter(...)` with direct `for...of` iterations and `if/continue` conditions.
🎯 **Why:** To prevent unnecessary intermediate array allocations, reducing both memory overhead and GC pressure. This loop is on the hot path for providing diagnostics inside the editor.
📊 **Measured Improvement:** Measured with a 100k element microbenchmark.
- Baseline (using `.filter(...)`): ~2298.76 ms 
- Optimized (using standard `for...of` and `if`): ~1870.73 ms
- Measured improvement: ~18.6% faster on iterations.

---
*PR created automatically by Jules for task [14592174319761975214](https://jules.google.com/task/14592174319761975214) started by @sorliekenison-crypto*